### PR TITLE
fixed icon background bug

### DIFF
--- a/components/quiz/message.tsx
+++ b/components/quiz/message.tsx
@@ -97,7 +97,7 @@ export function BotCard({
     <div className="group relative flex items-start md:-ml-12">
       <div
         className={cn(
-          'flex size-[60px] shrink-0 select-none items-center justify-center rounded-md border bg-primary text-primary-foreground shadow-sm',
+          'flex size-[60px] shrink-0 select-none items-center justify-center rounded-md border bg-background text-primary-foreground shadow-sm',
           !showAvatar && 'invisible'
         )}
       >
@@ -123,7 +123,7 @@ export function SystemMessage({ children }: { children: React.ReactNode }) {
 export function SpinnerMessage() {
   return (
     <div className="group relative flex items-start md:-ml-12">
-      <div className="flex size-[60px] shrink-0 select-none items-center justify-center rounded-md border bg-primary text-primary-foreground shadow-sm">
+      <div className="flex size-[60px] shrink-0 select-none items-center justify-center rounded-md border bg-background text-primary-foreground shadow-sm">
         <IconSoCcoach />
       </div>
       <div className="ml-4 h-[24px] flex flex-row items-center flex-1 space-y-2 overflow-hidden px-1">


### PR DESCRIPTION
Fixed bug - icon background in light mode was black for a second. This has now been fixed. Background is white at all times in light more and black at all times in the dark mode.