### PR TITLE
setting for serverless functions on Vercel to run 60 seconds instead of default 10

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,7 @@
+{
+    "functions": {
+      "app/**/*": {
+        "maxDuration": 60
+      }
+    }
+  }


### PR DESCRIPTION
Maximum serverless function duration for Hobby plan on Vercel is 10 seconds by default. Needs to be changed to 60 as the app is crashing when the responses are too long.