### PR TITLE
chat history no longer pushes chat responses to the side

### DIFF
--- a/app/(chat)/layout.tsx
+++ b/app/(chat)/layout.tsx
@@ -7,7 +7,9 @@ interface ChatLayoutProps {
 export default async function ChatLayout({ children }: ChatLayoutProps) {
   return (
     <div className="relative flex h-[calc(100vh_-_theme(spacing.16))] overflow-hidden">
-      <SidebarDesktop />
+      <div className="absolute h-full">
+        <SidebarDesktop />
+      </div>
       {children}
     </div>
   )

--- a/components/sidebar-desktop.tsx
+++ b/components/sidebar-desktop.tsx
@@ -11,7 +11,7 @@ export async function SidebarDesktop() {
   }
 
   return (
-    <Sidebar className="peer absolute inset-y-0 z-30 hidden -translate-x-full border-r bg-muted duration-300 mt-7 ease-in-out data-[state=open]:translate-x-0 lg:flex lg:w-[250px] xl:w-[300px]">
+    <Sidebar className="peer absolute inset-y-0 z-30 hidden -translate-x-full border-r bg-muted duration-300 mt-7 ease-in-out data-[state=open]:translate-x-0 lg:flex lg:w-[250px] xl:w-[300px] pb-4">
       {/* @ts-ignore */}
       <ChatHistory userId={session.user.id} />
     </Sidebar>


### PR DESCRIPTION
When a user has logged in and opens the chat history sidebar, the current chat content is no longer moved to the side.